### PR TITLE
Add custom_default_t (alternate approach)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ int main()
 ### Compile and run
 
 ```Text
-prompt> g++ -Wall -std=c++11 -I../include -o 01-basic 01-basic.cpp && ./01-basic 
+prompt> g++ -Wall -std=c++11 -I../include -o 01-basic 01-basic.cpp && ./01-basic
 ```
 
 ## In a nutshell
@@ -82,6 +82,7 @@ prompt> g++ -Wall -std=c++11 -I../include -o 01-basic 01-basic.cpp && ./01-basic
 
 - [Namespace and types](#syn-types)
 - [Create a default-constructible type](#syn-default-type)
+- [Create a default-constructible type with a custom value](#syn-custom-default-type)
 - [Create a non-default-constructible type](#syn-non-default-type)
 - [Create a sub-type](syn-sub-type)
 - [Define a function taking a strong type](#syn-function)
@@ -122,6 +123,16 @@ Using the macro:
 
 ```Cpp
 type_DEFINE_TYPE( Quantity, quantity, double )
+```
+
+<a id="syn-custom-default-type"></a>
+### Create a default-constructible type with a custom value
+
+Declaring default-constructible type Index with a non-zero default value ([example code](example/02a-custom-default.cpp)):
+
+```Cpp
+typedef nonstd::equality<size_t, struct IndexTag,
+    nonstd::custom_default_t<size_t, std::numeric_limits<size_t>::max()> > Index;
 ```
 
 <a id="syn-non-default-type"></a>
@@ -196,6 +207,7 @@ inline std::ostream & operator<<( std::ostream & os, nonstd::type<T,Tag,D> const
 | address               |&nbsp; | ordered&ensp;a&thinsp;-&thinsp;a&ensp;a&thinsp;+&thinsp;o&ensp;a&thinsp;-&thinsp;o&ensp;a&thinsp;+=&thinsp;o&ensp;a&thinsp;-=&thinsp;o&ensp; |
 | &nbsp;                |&nbsp; | &nbsp; |
 | no_default_t          |&nbsp; | used to make type non-default-constructible|
+| custom_default_t      |&nbsp; | used to specify a custom value for default construction|
 | &nbsp;                |&nbsp; | &nbsp; |
 | std::hash&lt;type&lt;...>>    | C++11  | hash type for `type` in namespace `std`; see `make_hash()` |
 | &nbsp;                |&nbsp; | &nbsp; |

--- a/example/02a-custom-default.cpp
+++ b/example/02a-custom-default.cpp
@@ -1,0 +1,14 @@
+#include "nonstd/type.hpp"
+#include <limits>
+
+typedef nonstd::equality<size_t, struct IndexTag,
+    nonstd::custom_default_t<size_t, std::numeric_limits<size_t>::max()> > Index;
+
+int main()
+{
+    Index i( 0 );
+    return i != Index() ? 0 : 1;
+}
+// g++ -Wall -std=c++98 -I../include -o 02a-custom-default 02a-custom-default.cpp && 02a-custom-default.exe
+// cl -nologo -W3 -EHsc -I../include 02a-custom-default.cpp && 02a-custom-default.exe
+// 02a-custom-default.exe & echo %ERRORLEVEL%

--- a/include/nonstd/type.hpp
+++ b/include/nonstd/type.hpp
@@ -288,6 +288,11 @@ template< typename R, typename T = R > struct bit_shr { friend type_constexpr14 
 struct no_default_t{};
 
 /**
+ * custom default value
+ */
+template<typename T, T Val> struct custom_default_t{};
+
+/**
  * data base class.
  */
 template< typename T, typename D = T >
@@ -330,6 +335,24 @@ private:
     underlying_type value;
 };
 
+template<typename T, typename D = T>
+struct default_value
+{
+    static type_constexpr T get()
+    {
+        return T();
+    }
+};
+
+template<typename T, T Val>
+struct default_value< T, custom_default_t< T, Val > >
+{
+    static type_constexpr T get()
+    {
+        return Val;
+    }
+};
+
 /**
  * type, no operators.
  */
@@ -342,7 +365,7 @@ struct type : data<T,D>
     ))
 #endif
     type_constexpr type()
-        : data<T,D>()
+        : data<T,D>( default_value<T,D>::get() )
     {}
 
 #if  type_CPP11_OR_GREATER
@@ -773,6 +796,7 @@ std::size_t make_hash( type<T,Tag,D> const & v ) type_noexcept
 namespace nonstd {
 
 using types::no_default_t;
+using types::custom_default_t;
 
 using types::type;
 using types::bits;

--- a/test/type.t.cpp
+++ b/test/type.t.cpp
@@ -186,6 +186,14 @@ CASE( "type: Allows to default-construct a type thus defined" )
     EXPECT( to_value( x ) == CopyMove() );
 }
 
+CASE( "type: Allows to custom-default-construct a type thus defined" )
+{
+    typedef type< int, struct Tag, custom_default_t< int, 5 > > CustomDefaultType;
+    CustomDefaultType x;
+
+    EXPECT( to_value( x ) == 5 );
+}
+
 CASE( "type: Allows to copy-construct a type from its underlying type" )
 {
     CopyMoveType x( CopyMove(7) );
@@ -313,6 +321,14 @@ CASE( "boolean: Allows to default-construct a boolean thus defined" )
     EXPECT( to_value( x ) == false );
 }
 
+CASE( "boolean: Allows to custom-default-construct a boolean thus defined" )
+{
+    typedef boolean< struct Tag, custom_default_t< bool, true > > CustomDefaultType;
+    CustomDefaultType x;
+
+    EXPECT( to_value( x ) == true );
+}
+
 CASE( "boolean: Allows to copy-construct a boolean from its underlying type" )
 {
     Boolean x( true );
@@ -364,6 +380,7 @@ typedef logical< CopyMove, struct Tag > CopyMoveLogical;
 typedef logical< MoveOnly, struct Tag > MoveOnlyLogical;
 typedef logical< bool    , struct Tag > BoolLogical;
 
+
 CASE( "logical: Disallows to default-construct a logical thus defined (define type_CONFIG_CONFIRMS_COMPILATION_ERRORS)" )
 {
 #if type_CONFIG_CONFIRMS_COMPILATION_ERRORS
@@ -377,6 +394,14 @@ CASE( "logical: Allows to default-construct a logical thus defined" )
     CopyMoveLogical x;
 
     EXPECT( to_value( x ) == CopyMove(0) );
+}
+
+CASE( "logical: Allows to custom-default-construct a logical thus defined" )
+{
+    typedef logical< int, struct Tag, custom_default_t< int, 5 > > CustomDefaultLogical;
+    CustomDefaultLogical x;
+
+    EXPECT( to_value( x ) == 5 );
 }
 
 CASE( "logical: Allows to copy-construct a logical from its underlying type" )
@@ -457,6 +482,14 @@ CASE( "equality: Allows to default-construct an equality thus defined" )
     EXPECT( to_value( x ) == CopyMove(0) );
 }
 
+CASE( "equality: Allows to custom-default-construct a equality thus defined" )
+{
+    typedef equality< int, struct Tag, custom_default_t< int, 5 > > CustomDefaultEquality;
+    CustomDefaultEquality x;
+
+    EXPECT( to_value( x ) == 5 );
+}
+
 CASE( "equality: Allows to copy-construct an equality from its underlying type" )
 {
     CopyMoveEquality x( CopyMove(7) );
@@ -516,6 +549,14 @@ CASE( "bits: Allows to default-construct a bits thus defined" )
     bits< unsigned int, struct Tag > x;
 
     EXPECT( to_value( x ) == 0u );
+}
+
+CASE( "bits: Allows to custom-default-construct a bits thus defined" )
+{
+    typedef bits< unsigned int, struct Tag, custom_default_t< unsigned int, 5 > > CustomDefaultBits;
+    CustomDefaultBits x;
+
+    EXPECT( to_value( x ) == 5 );
 }
 
 CASE( "bits: Allows to copy-construct a bits from its underlying type" )
@@ -662,6 +703,14 @@ CASE( "ordered: Allows to default-construct an ordered thus defined" )
     EXPECT( to_value( x ) == 0 );
 }
 
+CASE( "ordered: Allows to custom-default-construct an ordered thus defined" )
+{
+    typedef ordered< int, struct Tag, custom_default_t< int, 5 > > CustomDefaultOrdered;
+    CustomDefaultOrdered x;
+
+    EXPECT( to_value( x ) == 5 );
+}
+
 CASE( "ordered: Allows to copy-construct an ordered from its underlying type" )
 {
     CopyMoveOrdered x( CopyMove(7) );
@@ -737,6 +786,14 @@ CASE( "numeric: Allows to default-construct a numeric thus defined" )
     Numeric x;
 
     EXPECT( to_value( x ) == 0 );
+}
+
+CASE( "numeric: Allows to custom-default-construct a numeric thus defined" )
+{
+    typedef numeric< int, struct Tag, custom_default_t< int, 5 > > CustomDefaultNumeric;
+    CustomDefaultNumeric x;
+
+    EXPECT( to_value( x ) == 5 );
 }
 
 CASE( "numeric: Allows to copy-construct a numeric from its underlying type" )
@@ -883,6 +940,14 @@ CASE( "quantity: Allows to default-construct a quantity thus defined" )
     Quantity x;
 
     EXPECT( to_value( x ) == 0 );
+}
+
+CASE( "quantity: Allows to custom-default-construct a quantity thus defined" )
+{
+    typedef quantity< int, struct Tag, custom_default_t< int, 5 > > CustomDefaultQuantity;
+    CustomDefaultQuantity x;
+
+    EXPECT( to_value( x ) == 5 );
 }
 
 CASE( "quantity: Allows to copy-construct a quantity from its underlying type" )
@@ -1036,6 +1101,16 @@ CASE( "address: Allows to default-construct an address thus defined" )
 #endif
 }
 
+int sample = 0;
+
+CASE( "address: Allows to custom-default-construct a address thus defined" )
+{
+    typedef address< int*, std::ptrdiff_t, struct Tag, custom_default_t< int*, &sample > > CustomDefaultAddress;
+    CustomDefaultAddress x;
+
+    EXPECT( to_value( x ) == &sample );
+}
+
 CASE( "address: Allows to copy-construct an address from its underlying type" )
 {
     int i;
@@ -1153,6 +1228,14 @@ CASE( "offset: Allows to default-construct an offset thus defined" )
     Offset x;
 
     EXPECT( to_value( x ) == 0 );
+}
+
+CASE( "offset: Allows to custom-default-construct a offset thus defined" )
+{
+    typedef offset< int, struct Tag, custom_default_t< int, 5 > > CustomDefaultOffset;
+    CustomDefaultOffset x;
+
+    EXPECT( to_value( x ) == 5 );
 }
 
 CASE( "offset: Allows to copy-construct an offset from its underlying type" )

--- a/test/type.t.cpp
+++ b/test/type.t.cpp
@@ -323,7 +323,7 @@ CASE( "boolean: Allows to default-construct a boolean thus defined" )
 
 CASE( "boolean: Allows to custom-default-construct a boolean thus defined" )
 {
-    typedef boolean< struct Tag, custom_default_t< bool, true > > CustomDefaultType;
+    typedef nonstd::boolean< struct Tag, custom_default_t< bool, true > > CustomDefaultType;
     CustomDefaultType x;
 
     EXPECT( to_value( x ) == true );


### PR DESCRIPTION
This is a more minimal approach to the same functionality as #9, and works without partial specialization of type<>.
